### PR TITLE
Allow specifying devicename prefix and allow disabling LVM

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -68,3 +68,6 @@ additional_settings:
 
 # reboot after installing the new image
 reboot_installimage: true
+
+# allow to override which devices you want to be detected for installing the system
+installimage_device_prefix: sd

--- a/templates/installimage.j2
+++ b/templates/installimage.j2
@@ -1,8 +1,8 @@
 ## ====================
 ##  HARD DISK DRIVE(S):
 ## ====================
-{% for item in ansible_devices | dict2items if item.key.startswith("sd") %}
-# Onboard: {{ item.value.model }} {{ item.value.serial }}
+{% for item in ansible_devices | dict2items if item.key.startswith(installimage_device_prefix) %}
+# Onboard: {{ item.value.model | default('') }} {{ item.value.serial | default('') }}
 DRIVE{{ loop.index }} /dev/{{ item.key }}
 {% endfor %}
 

--- a/templates/installimage.j2
+++ b/templates/installimage.j2
@@ -32,9 +32,11 @@ SSHKEYS_URL {{ authorized_key_url }}
 PART {{ part.mountpoint }} {{ part.filesystem }} {{ part.size }}
 {% endfor %}
 # logical volume definitions
+{% if volumes -%}
 {% for lv in volumes -%}
 LV {{ lv.vg }} {{ lv.name }} {{ lv.mountpoint }} {{ lv.filesystem }} {{ lv.size }}
 {% endfor %}
+{% endif %}
 
 ## ========================
 ##  OPERATING SYSTEM IMAGE:


### PR DESCRIPTION
This modification allows to do 2 things:

1. Allow to specify a devicename prefix of devices which should be used for installation
2. Allow to disable LVM


## 1 Allow to override device name prefix of which devices are to be detected.
On systems with nvme disks present themselves as /dev/nvmeXpY, so we need to be able to set a prefix different than 'sd'. In our case:
`    installimage_device_prefix: nvme
`
## 2 Allow to disable LVM
If you want to disable LVM just set volumes to an empty hash:
`    
    volumes:
`